### PR TITLE
Add API key and SSH key support

### DIFF
--- a/napalm_panos/panos.py
+++ b/napalm_panos/panos.py
@@ -80,7 +80,6 @@ class PANOSDriver(NetworkDriver):
                 pass
         self.api_key = optional_args.get('api_key', '')
 
-
     def open(self):
         try:
             if self.api_key:

--- a/napalm_panos/panos.py
+++ b/napalm_panos/panos.py
@@ -36,7 +36,7 @@ from netmiko import __version__ as netmiko_version
 
 class PANOSDriver(NetworkDriver):
 
-    def __init__(self, hostname, username, password='', timeout=60, optional_args=None):
+    def __init__(self, hostname, username, password, timeout=60, optional_args=None):
         self.hostname = hostname
         self.username = username
         self.password = password


### PR DESCRIPTION
1/ Slightly similar to https://github.com/napalm-automation/napalm-ios/pull/59 this patch adds support for the following netmiko optional args:
port, verbose, use_keys, key_file, ssh_strict, system_host_keys, alt_host_keys, alt_key_file, ssh_config_file and allow_agent
This allows the SSH transport to use SSH keys instead of passwords.

2/ removed self.port = optional_args.get('port', 22)
That optional arg is defined in 1/  and its default value is set in netmiko to 22 (when using ssh) if not defined before
https://github.com/ktbyers/netmiko/blob/master/netmiko/base_connection.py#L48

3/ Adds the possibility to pass the https API key as optional args instead of username/password, this is to avoid storing cleartext password anywhere
