### PR TITLE
Catch KeyError Exception

### DIFF
--- a/napalm_panos/panos.py
+++ b/napalm_panos/panos.py
@@ -431,7 +431,7 @@ class PANOSDriver(NetworkDriver):
             routes_table_xml = xmltodict.parse(self.device.xml_root())
             routes_table_json = json.dumps(routes_table_xml['response']['result']['entry'])
             routes_table = json.loads(routes_table_json)
-        except AttributeError:
+        except (AttributeError, KeyError):
             routes_table = []
 
         if isinstance(routes_table, dict):

--- a/test/unit/mocked_data/test_get_facts/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_facts/normal/expected_result.json
@@ -1,1 +1,1 @@
-{"uptime": 79741, "vendor": "Palo Alto Networks", "hostname": "pa1", "fqdn": "N/A", "os_version": "7.0.1", "serial_number": "unknown", "model": "PA-VM", "interface_list": ["ethernet1/1", "ethernet1/2", "ethernet1/3", "ethernet1/4", "loopback"]}
+{"uptime": 1030141, "vendor": "Palo Alto Networks", "hostname": "pa1", "fqdn": "N/A", "os_version": "7.0.1", "serial_number": "unknown", "model": "PA-VM", "interface_list": ["ethernet1/1", "ethernet1/2", "ethernet1/3", "ethernet1/4", "loopback"]}


### PR DESCRIPTION
Catch KeyError exception in get_route_to() in the event that there are no routes to the requested destination in the routing table.
